### PR TITLE
tuning recovery to skip ancient prs

### DIFF
--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/scm/pr/service/PRScanningService.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/scm/pr/service/PRScanningService.java
@@ -158,11 +158,16 @@ public class PRScanningService extends AbstractScanningService {
 
 	private List<PullRequest> recoverByRepo(APIIntegrationEntity entity, IScmApi api,
 			RepositoryEntity repo) {
+		long repoLastReview = repo.getLastReviewedDate();
 		List<PullRequest> prUpdates = api.getOpenPullRequestsForRepository(repo.getRepoName())
 				.stream().filter(pr -> {
 					PullRequestContainerEntity prEntity =
 							prScanResultService.getPullRequestByLabelRepoAndId(entity.getApiLabel(),
 									repo.getRepoName(), pr.getPrId());
+					// This is an ancient pr and older than our last check on the repository.
+					if (repoLastReview > pr.getUpdateTime()) {
+						return false;
+					}
 					// if we haven't seen this PR add it
 					if (prEntity == null) {
 						return true;


### PR DESCRIPTION
if a repo has PRs in Bitbucket that are older than the day watchtower started, PR recovery tries to catch up with them. That's no good. So now we only scan things newer than the last time the repo had any scan.