### PR TITLE
Disallow provided rules overriding previously set rule priority

### DIFF
--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/rule/RuleService.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/rule/RuleService.java
@@ -158,16 +158,15 @@ public class RuleService {
 			RuleEntity found = ruleRepository.findByName(rule.getName());
 			if (found != null) {
 				if (rule.getRuleDesignation().equals(RuleDesignation.PROVIDED)) {
-					ProvidedRuleDto provided = (ProvidedRuleDto) rule;
 					// On update, only update the priority
 					if (providedOption.equals(ImportOption.SKIP)) {
-						LOG.debug("Skipping update of provided rule {}", provided.getName());
+						LOG.debug("Skipping update of provided rule {}", rule.getName());
 					} else if (providedOption.equals(ImportOption.UPDATE)) {
-						found.setPriority(provided.getPriority());
+						found.setPriority(rule.getPriority());
 						rules.add(found);
 					} else if (providedOption.equals(ImportOption.OVERRIDE)) {
 						// update the old rule with the new info
-						RuleEntity ruleEntity = provided.toEntity();
+						RuleEntity ruleEntity = rule.toEntity();
 						ruleEntity.setId(found.getId());
 						ruleEntity.setPriority(found.getPriority());
 						rules.add(ruleEntity);

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/rule/RuleService.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/rule/RuleService.java
@@ -158,16 +158,18 @@ public class RuleService {
 			RuleEntity found = ruleRepository.findByName(rule.getName());
 			if (found != null) {
 				if (rule.getRuleDesignation().equals(RuleDesignation.PROVIDED)) {
+					ProvidedRuleDto provided = (ProvidedRuleDto) rule;
 					// On update, only update the priority
 					if (providedOption.equals(ImportOption.SKIP)) {
-						LOG.debug("Skipping update of provided rule {}", rule.getName());
+						LOG.debug("Skipping update of provided rule {}", provided.getName());
 					} else if (providedOption.equals(ImportOption.UPDATE)) {
-						found.setPriority(rule.getPriority());
+						found.setPriority(provided.getPriority());
 						rules.add(found);
 					} else if (providedOption.equals(ImportOption.OVERRIDE)) {
 						// update the old rule with the new info
-						RuleEntity ruleEntity = rule.toEntity();
+						RuleEntity ruleEntity = provided.toEntity();
 						ruleEntity.setId(found.getId());
+						ruleEntity.setPriority(found.getPriority());
 						rules.add(ruleEntity);
 					}
 				} else {

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/ruleset/ImportOption.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/ruleset/ImportOption.java
@@ -32,7 +32,11 @@ public enum ImportOption {
 	 * <p>
 	 * --is not provided, update the blocking level, description, and designation
 	 * <p>
-	 * If the import object is a rule, update all data
+	 * If the import object is a rule and...
+	 * <p>
+	 * --is provided, update all data, but keep the existing priority
+	 * <p>
+	 * --is not provided, update all data
 	 */
 	OVERRIDE;
 


### PR DESCRIPTION
When importing provided rulesets, disallow a provided rule overriding a previously set rule priority. Custom rules still fully overwrite. Provided rules marked for update (during rule import, not provided ruleset import) will also update the priority still