### PR TITLE
PSEC-931 ECR Integration Tests

### DIFF
--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/configuration/RestSecurityConfig.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/configuration/RestSecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 
@@ -43,8 +42,6 @@ public class RestSecurityConfig extends SecurityConfig {
 				.authorizeRequests().anyRequest().permitAll()
 				.and()
 				.httpBasic().authenticationEntryPoint(authEntryPoint());
-
-		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 	}
 
 	/**

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanRestController.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanRestController.java
@@ -1,5 +1,13 @@
 package com.tracelink.appsec.watchtower.core.rest.scan.image;
 
+import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
+import com.tracelink.appsec.watchtower.core.exception.ScanRejectedException;
+import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationEntity;
+import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationException;
+import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationService;
+import com.tracelink.appsec.watchtower.core.scan.image.ImageScan;
+import com.tracelink.appsec.watchtower.core.scan.image.api.ecr.EcrImageScan;
+import com.tracelink.appsec.watchtower.core.scan.image.service.ImageScanningService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,20 +19,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
-import com.tracelink.appsec.watchtower.core.exception.ScanRejectedException;
-import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationEntity;
-import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationException;
-import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationService;
-import com.tracelink.appsec.watchtower.core.scan.image.ImageScan;
-import com.tracelink.appsec.watchtower.core.scan.image.api.ecr.EcrImageScan;
-import com.tracelink.appsec.watchtower.core.scan.image.service.ImageScanningService;
-
 /**
  * REST interface to begin an image scan
- * 
- * @author csmith
  *
+ * @author csmith
  */
 @RestController
 @RequestMapping("/rest/imagescan")
@@ -72,7 +70,7 @@ public class ImageScanRestController {
 				scan.populateFromRequest(imageScan);
 				return scan;
 			default:
-				throw new ApiIntegrationException("No SCM API for this label.");
+				throw new ApiIntegrationException("No image API for this label.");
 		}
 	}
 

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanResultController.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanResultController.java
@@ -1,9 +1,13 @@
 package com.tracelink.appsec.watchtower.core.rest.scan.image;
 
+import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
+import com.tracelink.appsec.watchtower.core.scan.image.result.ImageResultFilter;
+import com.tracelink.appsec.watchtower.core.scan.image.result.ImageScanResult;
+import com.tracelink.appsec.watchtower.core.scan.image.service.ImageScanResultService;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-
+import net.minidev.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -14,23 +18,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
-import com.tracelink.appsec.watchtower.core.scan.image.result.ImageResultFilter;
-import com.tracelink.appsec.watchtower.core.scan.image.result.ImageScanResult;
-import com.tracelink.appsec.watchtower.core.scan.image.service.ImageScanResultService;
-
-import net.minidev.json.JSONObject;
-
 /**
  * REST Contoller for Scan Results, including filtering
- * 
- * @author csmith
  *
+ * @author csmith
  */
 @RestController
 @RequestMapping("/rest/imagescan/result")
 @PreAuthorize("hasAuthority('" + CorePrivilege.SCAN_RESULTS_NAME + "')")
 public class ImageScanResultController {
+
 	private ImageScanResultService resultService;
 
 	public ImageScanResultController(@Autowired ImageScanResultService resultService) {
@@ -49,11 +46,11 @@ public class ImageScanResultController {
 				resultService.getScanResultsWithFilters(resultFilter, pageSize, pageNum);
 		String next =
 				uriBuilder
-						.replacePath(Paths.get("rest/scan/result", resultFilter.getName(),
+						.replacePath(Paths.get("rest/imagescan/result", resultFilter.getName(),
 								String.valueOf(pageNum + 1)).toString())
 						.build().encode().toUriString();
 		JSONObject obj = new JSONObject();
-		if (results.size() == pageSize) {
+		if (!results.isEmpty()) {
 			obj.put("next", next);
 		}
 		obj.put("results", results);

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/AbstractScanAgent.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/AbstractScanAgent.java
@@ -1,18 +1,16 @@
 package com.tracelink.appsec.watchtower.core.scan;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.tracelink.appsec.watchtower.core.benchmark.Benchmarker;
 import com.tracelink.appsec.watchtower.core.benchmark.WatchtowerBenchmarking;
 import com.tracelink.appsec.watchtower.core.benchmark.WatchtowerTimers;
 import com.tracelink.appsec.watchtower.core.exception.ScanInitializationException;
 import com.tracelink.appsec.watchtower.core.module.scanner.IScanner;
 import com.tracelink.appsec.watchtower.core.ruleset.RulesetDto;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles orchestration of individual scanners for scans of an SCM pull request. This class is
@@ -22,14 +20,15 @@ import com.tracelink.appsec.watchtower.core.ruleset.RulesetDto;
  * Collects reports and sends to the report method for implementations to manage. Finally, reports
  * on benchmarks, if configured and then starts a cleanup procedure for implementations
  *
- * @author csmith, mcool
  * @param <T> The type of {@link AbstractScanAgent} (for builder subclassing)
  * @param <S> The type of {@link IScanner} used to scan in this agent
  * @param <C> The type of {@link AbstractScanConfig} used to configure the scans
  * @param <R> The type of {@link AbstractScanReport} use to report findings from this scan
+ * @author csmith, mcool
  */
 public abstract class AbstractScanAgent<T extends AbstractScanAgent<T, S, C, R>, S extends IScanner<C, R>, C extends AbstractScanConfig, R extends AbstractScanReport>
 		implements Runnable {
+
 	private Logger LOG = LoggerFactory.getLogger(getClass());
 
 	private String scanName;
@@ -44,7 +43,7 @@ public abstract class AbstractScanAgent<T extends AbstractScanAgent<T, S, C, R>,
 
 	/**
 	 * Set the scanners for this Agent's configuration
-	 * 
+	 *
 	 * @param scanners the collection of scanners to use
 	 * @return this agent
 	 */
@@ -55,7 +54,7 @@ public abstract class AbstractScanAgent<T extends AbstractScanAgent<T, S, C, R>,
 
 	/**
 	 * Set the ruleset for this Agent's configuration
-	 * 
+	 *
 	 * @param ruleset the ruleset to use
 	 * @return this agent
 	 */
@@ -66,7 +65,7 @@ public abstract class AbstractScanAgent<T extends AbstractScanAgent<T, S, C, R>,
 
 	/**
 	 * Set whether this Agent should use benchmarking
-	 * 
+	 *
 	 * @param benchmarkEnabled true to enable, false to disable benchmarks
 	 * @return this agent
 	 */
@@ -122,7 +121,7 @@ public abstract class AbstractScanAgent<T extends AbstractScanAgent<T, S, C, R>,
 	/**
 	 * (Optional) Step to handle any exceptions encountered while processing. Defaults to doing
 	 * nothing.
-	 * 
+	 *
 	 * @param e the exception thrown
 	 */
 	protected void handleScanException(Exception e) {
@@ -131,7 +130,7 @@ public abstract class AbstractScanAgent<T extends AbstractScanAgent<T, S, C, R>,
 
 	/**
 	 * Does initialization routines and checks to ensure parameters are correct
-	 * 
+	 *
 	 * @throws ScanInitializationException if the scan cannot begin
 	 */
 	protected void initialize() throws ScanInitializationException {
@@ -149,7 +148,7 @@ public abstract class AbstractScanAgent<T extends AbstractScanAgent<T, S, C, R>,
 	/**
 	 * Performs individual scans of whatever is in the working directory, using the scanners
 	 * configured for this agent.
-	 * 
+	 *
 	 * @return list of reports from the scanner(s)
 	 */
 	protected List<R> scan() {
@@ -159,32 +158,42 @@ public abstract class AbstractScanAgent<T extends AbstractScanAgent<T, S, C, R>,
 		C config = createScanConfig();
 
 		for (S scanner : scanners) {
-			if (config.getRuleset().getAllRules().stream().noneMatch(
-					r -> scanner.getSupportedRuleClass() != null
-							&& scanner.getSupportedRuleClass().isInstance(r))) {
-				LOG.debug("No rules for scanner " + scanner.getClass().getSimpleName());
-			} else {
+			if (shouldRunScanner(scanner, config)) {
 				// Scan and format report
 				R report = scanner.scan(config);
 				if (config.isBenchmarkEnabled()) {
 					report.logRuleBenchmarking();
 				}
 				reports.add(report);
+			} else {
+				LOG.debug("Skipping scanner " + scanner.getClass().getSimpleName());
 			}
 		}
 		return reports;
 	}
 
 	/**
+	 * Determines whether the given scanner should be run based on the provided scan config
+	 *
+	 * @param scanner the scanner to run (or not)
+	 * @param config  the scan config for the scanning process
+	 * @return tru if the scanner should be run, false otherwise
+	 */
+	protected boolean shouldRunScanner(S scanner, C config) {
+		return scanner.getSupportedRuleClass() != null && config.getRuleset().getAllRules().stream()
+				.anyMatch(r -> scanner.getSupportedRuleClass().isInstance(r));
+	}
+
+	/**
 	 * Create the Scan Configuration for this scan
-	 * 
+	 *
 	 * @return the Scan Configuration
 	 */
 	protected abstract C createScanConfig();
 
 	/**
 	 * Do any necessary reporting given the raw reports from the scanners
-	 * 
+	 *
 	 * @param reports a list of reports given by the scanners
 	 */
 	protected abstract void report(List<R> reports);

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/apiintegration/ApiIntegrationEntity.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/apiintegration/ApiIntegrationEntity.java
@@ -113,6 +113,4 @@ public abstract class ApiIntegrationEntity {
 	 */
 	public abstract IWatchtowerApi createApi();
 
-	public abstract String getEndpointLink();
-
 }

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/apiintegration/ApiIntegrationEntity.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/apiintegration/ApiIntegrationEntity.java
@@ -113,4 +113,6 @@ public abstract class ApiIntegrationEntity {
 	 */
 	public abstract IWatchtowerApi createApi();
 
+	public abstract String getEndpointLink();
+
 }

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/image/api/ecr/EcrImageScan.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/image/api/ecr/EcrImageScan.java
@@ -2,6 +2,7 @@ package com.tracelink.appsec.watchtower.core.scan.image.api.ecr;
 
 import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationException;
 import com.tracelink.appsec.watchtower.core.scan.image.ImageScan;
+import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 
@@ -22,14 +23,17 @@ public class EcrImageScan extends ImageScan {
 	@Override
 	public void populateFromRequest(String requestBody) throws ApiIntegrationException {
 		JSONObject json = new JSONObject(requestBody);
-		String registryId = json.getString("registryId");
-		String repository = json.getString("repository");
-		String tag = json.getJSONArray("tags").optString(0);
-		if (StringUtils.isBlank(tag)) {
-			throw new ApiIntegrationException("No image tag specified");
+		String registryId = json.optString("registryId");
+		String repository = json.optString("repository");
+		JSONArray tags = json.optJSONArray("tags");
+		if (StringUtils.isBlank(registryId) || StringUtils.isBlank(repository) || tags == null
+				|| tags.isEmpty() || tags.isNull(0)) {
+			throw new ApiIntegrationException(
+					"Required params are 'registryId', 'repository', and a nonempty 'tags' array");
 		}
+
 		setRegistry(registryId);
 		setRepository(repository);
-		setTag(tag);
+		setTag(tags.getString(0));
 	}
 }

--- a/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/image/service/ImageScanAgent.java
+++ b/watchtower-core/src/main/java/com/tracelink/appsec/watchtower/core/scan/image/service/ImageScanAgent.java
@@ -1,12 +1,5 @@
 package com.tracelink.appsec.watchtower.core.scan.image.service;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.tracelink.appsec.watchtower.core.exception.ScanInitializationException;
 import com.tracelink.appsec.watchtower.core.module.scanner.IImageScanner;
 import com.tracelink.appsec.watchtower.core.ruleset.RulesetDto;
@@ -18,6 +11,11 @@ import com.tracelink.appsec.watchtower.core.scan.image.entity.AdvisoryEntity;
 import com.tracelink.appsec.watchtower.core.scan.image.entity.ImageViolationEntity;
 import com.tracelink.appsec.watchtower.core.scan.image.report.ImageScanError;
 import com.tracelink.appsec.watchtower.core.scan.image.report.ImageScanReport;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles orchestration of individual scanners for scans of an Image.
@@ -30,6 +28,7 @@ import com.tracelink.appsec.watchtower.core.scan.image.report.ImageScanReport;
  */
 public class ImageScanAgent extends
 		AbstractScanAgent<ImageScanAgent, IImageScanner, ImageScanConfig, ImageScanReport> {
+
 	private Logger LOG = LoggerFactory.getLogger(getClass());
 
 	private ImageScan scan;
@@ -49,7 +48,7 @@ public class ImageScanAgent extends
 
 	/**
 	 * Set the {@linkplain IImageApi} for this Agent's configuration
-	 * 
+	 *
 	 * @param api the {@linkplain IImageApi} to use
 	 * @return this agent
 	 */
@@ -60,7 +59,7 @@ public class ImageScanAgent extends
 
 	/**
 	 * Set the {@linkplain ImageScanResultService} for this Agent's configuration
-	 * 
+	 *
 	 * @param scanResultService the {@linkplain ImageScanResultService} to use
 	 * @return this agent
 	 */
@@ -71,7 +70,7 @@ public class ImageScanAgent extends
 
 	/**
 	 * Set the {@linkplain ImageAdvisoryService} for this Agent's configuration
-	 * 
+	 *
 	 * @param imageAdvisoryService the {@linkplain ImageAdvisoryService} to use
 	 * @return this agent
 	 */
@@ -96,6 +95,14 @@ public class ImageScanAgent extends
 		if (imageAdvisoryService == null) {
 			throw new ScanInitializationException("Image Advisory Service must be configured");
 		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected boolean shouldRunScanner(IImageScanner scanner, ImageScanConfig config) {
+		return true;
 	}
 
 	/**

--- a/watchtower-core/src/main/resources/db/migration/V028__API_Integration_Add_Register_Columns.sql
+++ b/watchtower-core/src/main/resources/db/migration/V028__API_Integration_Add_Register_Columns.sql
@@ -1,3 +1,6 @@
-ALTER TABLE integration_entity ADD COLUMN register_state varchar(255) NOT NULL;
+ALTER TABLE integration_entity ADD COLUMN register_state varchar(255);
 ALTER TABLE integration_entity ADD COLUMN register_error varchar(255);
 ALTER TABLE integration_entity ADD COLUMN watchtower_secret varchar(255);
+
+UPDATE integration_entity SET register_state = 'NOT_SUPPORTED';
+ALTER TABLE integration_entity MODIFY COLUMN register_state varchar(255) NOT NULL;

--- a/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanRestControllerTest.java
+++ b/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanRestControllerTest.java
@@ -1,0 +1,133 @@
+package com.tracelink.appsec.watchtower.core.rest.scan.image;
+
+import com.tracelink.appsec.watchtower.core.WatchtowerTestApplication;
+import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
+import com.tracelink.appsec.watchtower.core.exception.ScanRejectedException;
+import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationEntity;
+import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationService;
+import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiType;
+import com.tracelink.appsec.watchtower.core.scan.image.ImageScan;
+import com.tracelink.appsec.watchtower.core.scan.image.service.ImageScanningService;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = WatchtowerTestApplication.class)
+@AutoConfigureMockMvc
+public class ImageScanRestControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private ImageScanningService mockImageScanningService;
+
+	@MockBean
+	private ApiIntegrationService mockApiIntegrationService;
+
+	@Test
+	@WithMockUser(authorities = {
+			CorePrivilege.INTEGRATION_SCAN_SUBMIT}, username = "integrationLabel")
+	public void testScanImageRequest() throws Exception {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiType()).thenReturn(ApiType.ECR);
+		BDDMockito.when(mockApiIntegrationService.findByLabel(BDDMockito.anyString()))
+				.thenReturn(integrationEntity);
+		mockMvc.perform(MockMvcRequestBuilders.post("/rest/imagescan/integrationLabel")
+				.content("{\"registryId\":\"123\",\"repository\":\"image\",\"tags\":[\"latest\"]}"))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andExpect(MockMvcResultMatchers.content().string("Added scan successfully"));
+
+		ArgumentCaptor<ImageScan> imageScanCaptor = ArgumentCaptor.forClass(ImageScan.class);
+		BDDMockito.verify(mockImageScanningService).doImageScan(imageScanCaptor.capture());
+
+		ImageScan imageScan = imageScanCaptor.getValue();
+		MatcherAssert.assertThat(imageScan.getRegistry(), Matchers.is("123"));
+		MatcherAssert.assertThat(imageScan.getRepository(), Matchers.is("image"));
+		MatcherAssert.assertThat(imageScan.getTag(), Matchers.is("latest"));
+	}
+
+	@Test
+	@WithMockUser(authorities = {
+			CorePrivilege.INTEGRATION_SCAN_SUBMIT}, username = "integrationLabel")
+	public void testScanImageRequestNoEntity() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders.post("/rest/imagescan/integrationLabel")
+				.content("{\"registryId\":\"123\",\"repository\":\"image\",\"tags\":[\"latest\"]}"))
+				.andExpect(MockMvcResultMatchers.status().isBadRequest())
+				.andExpect(MockMvcResultMatchers.content().string("Unknown api label"));
+
+		BDDMockito.verify(mockImageScanningService, Mockito.times(0))
+				.doImageScan(BDDMockito.any());
+	}
+
+	@Test
+	@WithMockUser(authorities = {
+			CorePrivilege.INTEGRATION_SCAN_SUBMIT}, username = "integrationLabel")
+	public void testScanImageRequestScanRejected() throws Exception {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiType()).thenReturn(ApiType.ECR);
+		BDDMockito.when(mockApiIntegrationService.findByLabel(BDDMockito.anyString()))
+				.thenReturn(integrationEntity);
+		BDDMockito.doThrow(new ScanRejectedException("Bad scan")).when(mockImageScanningService)
+				.doImageScan(BDDMockito.any(ImageScan.class));
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/rest/imagescan/integrationLabel")
+				.content("{\"registryId\":\"123\",\"repository\":\"image\",\"tags\":[\"latest\"]}"))
+				.andExpect(MockMvcResultMatchers.status().isBadRequest())
+				.andExpect(MockMvcResultMatchers.content().string("Bad scan"));
+	}
+
+	@Test
+	@WithMockUser(authorities = {
+			CorePrivilege.INTEGRATION_SCAN_SUBMIT}, username = "integrationLabel")
+	public void testScanImageRequestBadParams() throws Exception {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiType()).thenReturn(ApiType.ECR);
+		BDDMockito.when(mockApiIntegrationService.findByLabel(BDDMockito.anyString()))
+				.thenReturn(integrationEntity);
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/rest/imagescan/integrationLabel")
+				.content("{\"repository\":\"image\",\"tags\":[\"latest\"]}"))
+				.andExpect(MockMvcResultMatchers.status().isBadRequest())
+				.andExpect(MockMvcResultMatchers.content()
+						.string("Error adding the scan: Required params are 'registryId', 'repository', and a nonempty 'tags' array"));
+
+		BDDMockito.verify(mockImageScanningService, Mockito.times(0)).doImageScan(BDDMockito.any());
+	}
+
+	@Test
+	@WithMockUser(authorities = {
+			CorePrivilege.INTEGRATION_SCAN_SUBMIT}, username = "integrationLabel")
+	public void testScanImageRequestBadApiType() throws Exception {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		ApiType mockApiType = BDDMockito.mock(ApiType.class);
+		BDDMockito.when(integrationEntity.getApiType()).thenReturn(mockApiType);
+		BDDMockito.when(mockApiIntegrationService.findByLabel(BDDMockito.anyString()))
+				.thenReturn(integrationEntity);
+
+		mockMvc.perform(MockMvcRequestBuilders.post("/rest/imagescan/integrationLabel")
+				.content("{\"repository\":\"image\",\"tags\":[\"latest\"]}"))
+				.andExpect(MockMvcResultMatchers.status().isBadRequest())
+				.andExpect(MockMvcResultMatchers.content()
+						.string("Error adding the scan: No image API for this label."));
+
+		BDDMockito.verify(mockImageScanningService, Mockito.times(0)).doImageScan(BDDMockito.any());
+	}
+
+}
+

--- a/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanRestResultControllerTest.java
+++ b/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanRestResultControllerTest.java
@@ -1,0 +1,90 @@
+package com.tracelink.appsec.watchtower.core.rest.scan.image;
+
+import com.tracelink.appsec.watchtower.core.WatchtowerTestApplication;
+import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
+import com.tracelink.appsec.watchtower.core.scan.image.result.ImageResultFilter;
+import com.tracelink.appsec.watchtower.core.scan.image.result.ImageScanResult;
+import com.tracelink.appsec.watchtower.core.scan.image.service.ImageScanResultService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = WatchtowerTestApplication.class)
+@AutoConfigureMockMvc
+public class ImageScanRestResultControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private ImageScanResultService mockScanResultService;
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.SCAN_RESULTS_NAME}, username = "user")
+	public void testResult() throws Exception {
+		ImageScanResult result = new ImageScanResult();
+		result.setApiLabel("foo");
+
+		BDDMockito
+				.when(mockScanResultService
+						.getScanResultsWithFilters(ImageResultFilter.ALL, 10, 0))
+				.thenReturn(Arrays.asList(result));
+
+		JSONObject jsonContent = new JSONObject();
+		jsonContent.put("next", "http://localhost/rest/imagescan/result/all/1");
+		jsonContent.put("results", Arrays.asList(result));
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/rest/imagescan/result"))
+				.andExpect(MockMvcResultMatchers.content().json(jsonContent.toString()));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.SCAN_RESULTS_NAME}, username = "user")
+	public void testResultSpecific() throws Exception {
+		ImageScanResult result = new ImageScanResult();
+		result.setApiLabel("foo");
+
+		BDDMockito
+				.when(mockScanResultService
+						.getScanResultsWithFilters(ImageResultFilter.VIOLATIONS, 10, 1))
+				.thenReturn(Arrays.asList(result));
+
+		JSONObject jsonContent = new JSONObject();
+		jsonContent.put("next", "http://localhost/rest/imagescan/result/violations/2");
+		jsonContent.put("results", Arrays.asList(result));
+
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/rest/imagescan/result/" + ImageResultFilter.VIOLATIONS.getName() + "/1"))
+				.andExpect(MockMvcResultMatchers.content().json(jsonContent.toString()));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.SCAN_RESULTS_NAME}, username = "user")
+	public void testResultEnd() throws Exception {
+		BDDMockito
+				.when(mockScanResultService
+						.getScanResultsWithFilters(ImageResultFilter.VIOLATIONS, 10, 1))
+				.thenReturn(new ArrayList<>());
+
+		JSONObject jsonContent = new JSONObject();
+		jsonContent.put("results", new ArrayList<>());
+
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/rest/imagescan/result/" + ImageResultFilter.VIOLATIONS.getName() + "/1"))
+				.andExpect(MockMvcResultMatchers.content().json(jsonContent.toString()));
+	}
+}

--- a/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanResultControllerTest.java
+++ b/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/rest/scan/image/ImageScanResultControllerTest.java
@@ -1,8 +1,13 @@
 package com.tracelink.appsec.watchtower.core.rest.scan.image;
 
+import com.tracelink.appsec.watchtower.core.WatchtowerTestApplication;
+import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
+import com.tracelink.appsec.watchtower.core.scan.image.result.ImageScanResult;
+import com.tracelink.appsec.watchtower.core.scan.image.result.ImageScanResultTest;
+import com.tracelink.appsec.watchtower.core.scan.image.service.ImageScanResultService;
 import java.util.Arrays;
 import java.util.List;
-
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
@@ -17,18 +22,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import com.tracelink.appsec.watchtower.core.WatchtowerTestApplication;
-import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
-import com.tracelink.appsec.watchtower.core.scan.image.result.ImageScanResult;
-import com.tracelink.appsec.watchtower.core.scan.image.result.ImageScanResultTest;
-import com.tracelink.appsec.watchtower.core.scan.image.service.ImageScanResultService;
-
-import net.minidev.json.JSONObject;
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = WatchtowerTestApplication.class)
 @AutoConfigureMockMvc
 public class ImageScanResultControllerTest {
+
 	@Autowired
 	private MockMvc mockMvc;
 
@@ -71,7 +69,7 @@ public class ImageScanResultControllerTest {
 
 		JSONObject json = new JSONObject();
 		json.put("results", results);
-		json.put("next", "http://localhost/rest/scan/result/all/1");
+		json.put("next", "http://localhost/rest/imagescan/result/all/1");
 		String jsonString = springMvcJacksonConverter.getObjectMapper().writeValueAsString(json);
 
 		mockMvc.perform(MockMvcRequestBuilders

--- a/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/scan/apiintegration/ApiIntegrationControllerTest.java
+++ b/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/scan/apiintegration/ApiIntegrationControllerTest.java
@@ -1,8 +1,13 @@
 package com.tracelink.appsec.watchtower.core.scan.apiintegration;
 
+import com.tracelink.appsec.watchtower.core.WatchtowerTestApplication;
+import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
+import com.tracelink.appsec.watchtower.core.mvc.WatchtowerModelAndView;
+import com.tracelink.appsec.watchtower.core.scan.IWatchtowerApi;
+import com.tracelink.appsec.watchtower.core.scan.code.scm.api.bb.BBCloudIntegrationEntity;
+import com.tracelink.appsec.watchtower.core.scan.image.api.ecr.EcrIntegrationEntity;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,11 +22,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-
-import com.tracelink.appsec.watchtower.core.WatchtowerTestApplication;
-import com.tracelink.appsec.watchtower.core.auth.model.CorePrivilege;
-import com.tracelink.appsec.watchtower.core.mvc.WatchtowerModelAndView;
-import com.tracelink.appsec.watchtower.core.scan.code.scm.api.bb.BBCloudIntegrationEntity;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = WatchtowerTestApplication.class)
@@ -150,14 +150,32 @@ public class ApiIntegrationControllerTest {
 	@Test
 	@WithMockUser(authorities = {CorePrivilege.API_SETTINGS_MODIFY_NAME})
 	public void testUpdateSettings() throws Exception {
-		String apiLabel = ApiType.BITBUCKET_CLOUD.getTypeName();
+		String apiType = ApiType.BITBUCKET_CLOUD.getTypeName();
 		mockMvc.perform(
-				MockMvcRequestBuilders.post("/apisettings/update").param("apiType", apiLabel)
+				MockMvcRequestBuilders.post("/apisettings/update").param("apiType", apiType)
 						.param("apiLabel", "a").param("workspace", "a").param("user", "a")
 						.param("auth", "a").with(SecurityMockMvcRequestPostProcessors.csrf()));
 
 		BDDMockito.verify(mockApiService)
 				.upsertEntity(BDDMockito.any(BBCloudIntegrationEntity.class));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.API_SETTINGS_MODIFY_NAME})
+	public void testUpdateSettingsFailure() throws Exception {
+		String apiLabel = ApiType.ECR.getTypeName();
+		BDDMockito.doThrow(new IllegalArgumentException("Something bad")).when(mockApiService)
+				.upsertEntity(BDDMockito.any());
+		mockMvc.perform(
+				MockMvcRequestBuilders.post("/apisettings/update").param("apiType", apiLabel)
+						.param("apiLabel", "a").param("region", "a").param("registryId", "a")
+						.param("awsAccessKey", "a").param("awsSecretKey", "a")
+						.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(MockMvcResultMatchers.flash()
+						.attribute(WatchtowerModelAndView.FAILURE_NOTIFICATION, "Something bad"));
+
+		BDDMockito.verify(mockApiService)
+				.upsertEntity(BDDMockito.any(EcrIntegrationEntity.class));
 	}
 
 
@@ -175,5 +193,102 @@ public class ApiIntegrationControllerTest {
 				.andExpect(MockMvcResultMatchers.flash()
 						.attribute(WatchtowerModelAndView.FAILURE_NOTIFICATION,
 								"Unknown API Label"));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.API_SETTINGS_VIEW_NAME})
+	public void testTestConnection() throws Exception {
+		IWatchtowerApi api = BDDMockito.mock(IWatchtowerApi.class);
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.createApi()).thenReturn(api);
+		BDDMockito.when(mockApiService.findByLabel(BDDMockito.anyString()))
+				.thenReturn(integrationEntity);
+		String apiLabel = "myIntegration";
+		mockMvc.perform(
+				MockMvcRequestBuilders.post("/apisettings/testConnection")
+						.param("apiLabel", apiLabel)
+						.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(MockMvcResultMatchers.flash()
+						.attribute(WatchtowerModelAndView.SUCCESS_NOTIFICATION,
+								"Success"));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.API_SETTINGS_VIEW_NAME})
+	public void testTestConnectionFailure() throws Exception {
+		IWatchtowerApi api = BDDMockito.mock(IWatchtowerApi.class);
+		BDDMockito.doThrow(new ApiIntegrationException("Bad connection")).when(api)
+				.testClientConnection();
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.createApi()).thenReturn(api);
+		BDDMockito.when(mockApiService.findByLabel(BDDMockito.anyString()))
+				.thenReturn(integrationEntity);
+
+		String apiLabel = "myIntegration";
+		mockMvc.perform(
+				MockMvcRequestBuilders.post("/apisettings/testConnection")
+						.param("apiLabel", apiLabel)
+						.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(MockMvcResultMatchers.flash()
+						.attribute(WatchtowerModelAndView.FAILURE_NOTIFICATION,
+								"Bad connection"));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.API_SETTINGS_VIEW_NAME})
+	public void testRegister() throws Exception {
+		String apiLabel = "myIntegration";
+		mockMvc.perform(
+				MockMvcRequestBuilders.post("/apisettings/register")
+						.param("apiLabel", apiLabel)
+						.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(MockMvcResultMatchers.flash()
+						.attribute(WatchtowerModelAndView.SUCCESS_NOTIFICATION,
+								"Started registration"));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.API_SETTINGS_VIEW_NAME})
+	public void testRegisterFailure() throws Exception {
+		String apiLabel = "myIntegration";
+		BDDMockito.doThrow(new ApiIntegrationException("Bad registration")).when(mockApiService)
+				.register(apiLabel);
+
+		mockMvc.perform(
+				MockMvcRequestBuilders.post("/apisettings/register")
+						.param("apiLabel", apiLabel)
+						.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(MockMvcResultMatchers.flash()
+						.attribute(WatchtowerModelAndView.FAILURE_NOTIFICATION,
+								"Bad registration"));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.API_SETTINGS_VIEW_NAME})
+	public void testUnregister() throws Exception {
+		String apiLabel = "myIntegration";
+		mockMvc.perform(
+				MockMvcRequestBuilders.post("/apisettings/unregister")
+						.param("apiLabel", apiLabel)
+						.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(MockMvcResultMatchers.flash()
+						.attribute(WatchtowerModelAndView.SUCCESS_NOTIFICATION,
+								"Started registration removal"));
+	}
+
+	@Test
+	@WithMockUser(authorities = {CorePrivilege.API_SETTINGS_VIEW_NAME})
+	public void testUnregisterFailure() throws Exception {
+		String apiLabel = "myIntegration";
+		BDDMockito.doThrow(new ApiIntegrationException("Bad unregistration")).when(mockApiService)
+				.unregister(apiLabel);
+
+		mockMvc.perform(
+				MockMvcRequestBuilders.post("/apisettings/unregister")
+						.param("apiLabel", apiLabel)
+						.with(SecurityMockMvcRequestPostProcessors.csrf()))
+				.andExpect(MockMvcResultMatchers.flash()
+						.attribute(WatchtowerModelAndView.FAILURE_NOTIFICATION,
+								"Bad unregistration"));
 	}
 }

--- a/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/scan/apiintegration/ApiIntegrationServiceTest.java
+++ b/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/scan/apiintegration/ApiIntegrationServiceTest.java
@@ -1,5 +1,7 @@
 package com.tracelink.appsec.watchtower.core.scan.apiintegration;
 
+import com.tracelink.appsec.watchtower.core.scan.IWatchtowerApi;
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -7,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -27,7 +30,7 @@ public class ApiIntegrationServiceTest {
 	}
 
 	@Test
-	public void testUpdate() throws ApiIntegrationException {
+	public void testUpdate() {
 		ApiIntegrationEntity apiEntity = BDDMockito.mock(ApiIntegrationEntity.class);
 		BDDMockito.when(apiEntity.getApiLabel()).thenReturn("test");
 		apiService.save(apiEntity);
@@ -82,5 +85,209 @@ public class ApiIntegrationServiceTest {
 	public void testGetAll() {
 		apiService.getAllSettings();
 		BDDMockito.verify(apiRepo).findAll();
+	}
+
+	@Test
+	public void testUpsertEntity() {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(integrationEntity.getIntegrationId()).thenReturn(1L);
+		BDDMockito.when(apiRepo.findByApiLabel(BDDMockito.anyString()))
+				.thenReturn(integrationEntity);
+
+		apiService.upsertEntity(integrationEntity);
+		BDDMockito.verify(apiRepo).saveAndFlush(integrationEntity);
+	}
+
+	@Test
+	public void testUpsertEntityNew() {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(apiRepo.findByApiLabel(BDDMockito.anyString())).thenReturn(null);
+
+		apiService.upsertEntity(integrationEntity);
+		BDDMockito.verify(apiRepo).saveAndFlush(integrationEntity);
+	}
+
+	@Test
+	public void testUpsertEntityExistingApiLabel() {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(integrationEntity.getIntegrationId()).thenReturn(2L);
+
+		ApiIntegrationEntity savedEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(savedEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(savedEntity.getIntegrationId()).thenReturn(1L);
+		BDDMockito.when(apiRepo.findByApiLabel(BDDMockito.anyString()))
+				.thenReturn(savedEntity);
+		try {
+			apiService.upsertEntity(integrationEntity);
+			MatcherAssert.assertThat("Exception not thrown", false);
+		} catch (IllegalArgumentException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					Matchers.is("There is already an API integration with this label"));
+		}
+		BDDMockito.verify(apiRepo, Mockito.times(0)).saveAndFlush(integrationEntity);
+	}
+
+	@Test
+	public void testFindById() {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(apiRepo.findById(1L)).thenReturn(Optional.of(integrationEntity));
+		MatcherAssert.assertThat(apiService.findById(1L), Matchers.is(integrationEntity));
+		BDDMockito.verify(apiRepo).findById(1L);
+	}
+
+	@Test
+	public void testFindByIdNull() {
+		BDDMockito.when(apiRepo.findById(1L)).thenReturn(Optional.empty());
+		MatcherAssert.assertThat(apiService.findById(1L), Matchers.nullValue());
+		BDDMockito.verify(apiRepo).findById(1L);
+	}
+
+	@Test
+	public void testRegister() throws Exception {
+		IWatchtowerApi api = BDDMockito.mock(IWatchtowerApi.class);
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(integrationEntity.getIntegrationId()).thenReturn(1L);
+		BDDMockito.when(integrationEntity.getRegisterState())
+				.thenReturn(RegisterState.NOT_REGISTERED);
+		BDDMockito.when(integrationEntity.createApi()).thenReturn(api);
+
+		BDDMockito.when(apiRepo.findByApiLabel("myIntegration")).thenReturn(integrationEntity);
+
+		apiService.register("myIntegration");
+
+		BDDMockito.verify(integrationEntity).setRegisterState(RegisterState.IN_PROGRESS);
+		BDDMockito.verify(apiRepo).saveAndFlush(integrationEntity);
+		BDDMockito.verify(api).register(passwordEncoder);
+	}
+
+	@Test
+	public void testRegisterFailure() throws Exception {
+		IWatchtowerApi api = BDDMockito.mock(IWatchtowerApi.class);
+		BDDMockito.doThrow(new IllegalArgumentException("Bad registration")).when(api)
+				.register(passwordEncoder);
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(integrationEntity.getIntegrationId()).thenReturn(1L);
+		BDDMockito.when(integrationEntity.getRegisterState())
+				.thenReturn(RegisterState.NOT_REGISTERED);
+		BDDMockito.when(integrationEntity.createApi()).thenReturn(api);
+
+		BDDMockito.when(apiRepo.findByApiLabel("myIntegration")).thenReturn(integrationEntity);
+
+		apiService.register("myIntegration");
+
+		BDDMockito.verify(integrationEntity).setRegisterState(RegisterState.IN_PROGRESS);
+		BDDMockito.verify(apiRepo).saveAndFlush(integrationEntity);
+		BDDMockito.verify(api).register(passwordEncoder);
+	}
+
+	@Test
+	public void testRegisterUnknownApiLabel() {
+		try {
+			apiService.register("myIntegration");
+			MatcherAssert.assertThat("Exception not thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(), Matchers.is("Unknown API integration label"));
+		}
+
+		BDDMockito.verify(apiRepo, Mockito.times(0)).saveAndFlush(BDDMockito.any());
+	}
+
+	@Test
+	public void testRegisterInvalidState() {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(integrationEntity.getIntegrationId()).thenReturn(1L);
+		BDDMockito.when(integrationEntity.getRegisterState())
+				.thenReturn(RegisterState.NOT_SUPPORTED);
+
+		BDDMockito.when(apiRepo.findByApiLabel("myIntegration")).thenReturn(integrationEntity);
+
+		try {
+			apiService.register("myIntegration");
+			MatcherAssert.assertThat("Exception not thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					Matchers.is("API integration cannot be registered in state Not Supported"));
+		}
+
+		BDDMockito.verify(apiRepo, Mockito.times(0)).saveAndFlush(integrationEntity);
+	}
+
+	@Test
+	public void testUnregister() throws Exception {
+		IWatchtowerApi api = BDDMockito.mock(IWatchtowerApi.class);
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(integrationEntity.getIntegrationId()).thenReturn(1L);
+		BDDMockito.when(integrationEntity.getRegisterState())
+				.thenReturn(RegisterState.REGISTERED);
+		BDDMockito.when(integrationEntity.createApi()).thenReturn(api);
+
+		BDDMockito.when(apiRepo.findByApiLabel("myIntegration")).thenReturn(integrationEntity);
+
+		apiService.unregister("myIntegration");
+
+		BDDMockito.verify(integrationEntity).setRegisterState(RegisterState.IN_PROGRESS);
+		BDDMockito.verify(integrationEntity).setRegisterError(null);
+		BDDMockito.verify(api).unregister();
+	}
+
+	@Test
+	public void testUnregisterFailure() throws Exception {
+		IWatchtowerApi api = BDDMockito.mock(IWatchtowerApi.class);
+		BDDMockito.doThrow(new IllegalArgumentException("Bad unregistration")).when(api)
+				.unregister();
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(integrationEntity.getIntegrationId()).thenReturn(1L);
+		BDDMockito.when(integrationEntity.getRegisterState())
+				.thenReturn(RegisterState.FAILED);
+		BDDMockito.when(integrationEntity.createApi()).thenReturn(api);
+
+		BDDMockito.when(apiRepo.findByApiLabel("myIntegration")).thenReturn(integrationEntity);
+
+		apiService.unregister("myIntegration");
+
+		BDDMockito.verify(integrationEntity).setRegisterState(RegisterState.IN_PROGRESS);
+		BDDMockito.verify(integrationEntity).setRegisterError(null);
+		BDDMockito.verify(api).unregister();
+	}
+
+	@Test
+	public void testUnregisterUnknownApiLabel() {
+		try {
+			apiService.unregister("myIntegration");
+			MatcherAssert.assertThat("Exception not thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(), Matchers.is("Unknown API integration label"));
+		}
+
+		BDDMockito.verify(apiRepo, Mockito.times(0)).saveAndFlush(BDDMockito.any());
+	}
+
+	@Test
+	public void testUnregisterInvalidState() {
+		ApiIntegrationEntity integrationEntity = BDDMockito.mock(ApiIntegrationEntity.class);
+		BDDMockito.when(integrationEntity.getApiLabel()).thenReturn("myIntegration");
+		BDDMockito.when(integrationEntity.getIntegrationId()).thenReturn(1L);
+		BDDMockito.when(integrationEntity.getRegisterState())
+				.thenReturn(RegisterState.NOT_REGISTERED);
+
+		BDDMockito.when(apiRepo.findByApiLabel("myIntegration")).thenReturn(integrationEntity);
+
+		try {
+			apiService.unregister("myIntegration");
+			MatcherAssert.assertThat("Exception not thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					Matchers.is("API integration cannot be unregistered in state Not Registered"));
+		}
+
+		BDDMockito.verify(apiRepo, Mockito.times(0)).saveAndFlush(integrationEntity);
 	}
 }

--- a/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/scan/image/api/ecr/EcrApiTest.java
+++ b/watchtower-core/src/test/java/com/tracelink/appsec/watchtower/core/scan/image/api/ecr/EcrApiTest.java
@@ -1,0 +1,530 @@
+package com.tracelink.appsec.watchtower.core.scan.image.api.ecr;
+
+import com.tracelink.appsec.watchtower.core.logging.CoreLogWatchExtension;
+import com.tracelink.appsec.watchtower.core.rule.RulePriority;
+import com.tracelink.appsec.watchtower.core.scan.apiintegration.ApiIntegrationException;
+import com.tracelink.appsec.watchtower.core.scan.image.ImageScan;
+import com.tracelink.appsec.watchtower.core.scan.image.ImageSecurityReport;
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.CloudFormationException;
+import software.amazon.awssdk.services.cloudformation.model.CreateStackRequest;
+import software.amazon.awssdk.services.cloudformation.model.CreateStackResponse;
+import software.amazon.awssdk.services.cloudformation.model.DeleteStackRequest;
+import software.amazon.awssdk.services.cloudformation.model.DeleteStackResponse;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksRequest;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksResponse;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.cloudformation.waiters.CloudFormationWaiter;
+import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.Attribute;
+import software.amazon.awssdk.services.ecr.model.BatchDeleteImageRequest;
+import software.amazon.awssdk.services.ecr.model.BatchDeleteImageResponse;
+import software.amazon.awssdk.services.ecr.model.DescribeImageScanFindingsRequest;
+import software.amazon.awssdk.services.ecr.model.DescribeImageScanFindingsResponse;
+import software.amazon.awssdk.services.ecr.model.FindingSeverity;
+import software.amazon.awssdk.services.ecr.model.ImageFailure;
+import software.amazon.awssdk.services.ecr.model.ImageScanFinding;
+import software.amazon.awssdk.services.ecr.model.ImageScanFindings;
+import software.amazon.awssdk.services.ecr.paginators.DescribeImageScanFindingsIterable;
+
+@ExtendWith(SpringExtension.class)
+public class EcrApiTest {
+
+	@RegisterExtension
+	public CoreLogWatchExtension logWatcher = CoreLogWatchExtension.forClass(EcrApi.class);
+
+	private EcrIntegrationEntity ecrIntegrationEntity;
+	private PasswordEncoder passwordEncoder;
+
+	@BeforeEach
+	public void setup() {
+		ecrIntegrationEntity = new EcrIntegrationEntity();
+		ecrIntegrationEntity.setApiLabel("ecrIntegration");
+		ecrIntegrationEntity.setRegion("us-east-1");
+		ecrIntegrationEntity.setRegistryId("1234567890");
+		ecrIntegrationEntity.setAwsAccessKey("foo");
+		ecrIntegrationEntity.setAwsSecretKey("bar");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+		passwordEncoder = BDDMockito.mock(PasswordEncoder.class);
+		BDDMockito.when(passwordEncoder.encode(BDDMockito.anyString()))
+				.thenAnswer(i -> i.getArguments()[0]);
+	}
+
+	/////
+	// Test Client Connection
+	/////
+	@Test
+	public void testClientConnectionFailCreateStack() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		ReflectionTestUtils
+				.setField(ecrApi, "cfClient",
+						getMockCloudFormationClient(403, 400, 200, false, "CREATE_COMPLETE"));
+
+		try {
+			ecrApi.testClientConnection();
+			MatcherAssert.assertThat("Exception should have been thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(), Matchers.is(
+					"Cannot create stack via CloudFormation: Received status code 403"));
+		}
+	}
+
+	@Test
+	public void testClientConnectionFailDeleteStack() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		ReflectionTestUtils
+				.setField(ecrApi, "cfClient",
+						getMockCloudFormationClient(400, 403, 200, false, "CREATE_COMPLETE"));
+
+		try {
+			ecrApi.testClientConnection();
+			MatcherAssert.assertThat("Exception should have been thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(), Matchers.is(
+					"Cannot delete stack via CloudFormation: Received status code 403"));
+		}
+	}
+
+	@Test
+	public void testClientConnectionFailDescribeStacks() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		ReflectionTestUtils
+				.setField(ecrApi, "cfClient",
+						getMockCloudFormationClient(400, 400, 403, false, "CREATE_COMPLETE"));
+
+		try {
+			ecrApi.testClientConnection();
+			MatcherAssert.assertThat("Exception should have been thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(), Matchers.is(
+					"Cannot describe stacks via CloudFormation: Received status code 403"));
+		}
+	}
+
+	@Test
+	public void testClientConnectionExceptionDescribeStacks() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		ReflectionTestUtils
+				.setField(ecrApi, "cfClient",
+						getMockCloudFormationClient(400, 400, 403, true, "Error occurred"));
+
+		try {
+			ecrApi.testClientConnection();
+			MatcherAssert.assertThat("Exception should have been thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(), Matchers.startsWith(
+					"Cannot describe stacks via CloudFormation: Error occurred"));
+		}
+	}
+
+	@Test
+	public void testClientConnectionFailDescribeFindings() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		ReflectionTestUtils
+				.setField(ecrApi, "cfClient",
+						getMockCloudFormationClient(400, 400, 200, true, "This is ok"));
+		ReflectionTestUtils
+				.setField(ecrApi, "ecrClient", getMockEcrClient(403, true, 400, false));
+
+		try {
+			ecrApi.testClientConnection();
+			MatcherAssert.assertThat("Exception should have been thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(), Matchers.is(
+					"Cannot get scan findings via ECR: Received status code 403"));
+		}
+	}
+
+	@Test
+	public void testClientConnectionFailDeleteImage() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		ReflectionTestUtils
+				.setField(ecrApi, "cfClient",
+						getMockCloudFormationClient(400, 400, 200, false, "CREATE_COMPLETE"));
+		ReflectionTestUtils
+				.setField(ecrApi, "ecrClient", getMockEcrClient(400, true, 403, false));
+
+		try {
+			ecrApi.testClientConnection();
+			MatcherAssert.assertThat("Exception should have been thrown", false);
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat(e.getMessage(), Matchers.is(
+					"Cannot delete image via ECR: Received status code 403"));
+		}
+	}
+
+	@Test
+	public void testClientConnectionSucceed() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		ReflectionTestUtils
+				.setField(ecrApi, "cfClient",
+						getMockCloudFormationClient(400, 400, 200, false, "CREATE_COMPLETE"));
+		ReflectionTestUtils
+				.setField(ecrApi, "ecrClient", getMockEcrClient(400, true, 400, false));
+
+		try {
+			ecrApi.testClientConnection();
+		} catch (ApiIntegrationException e) {
+			MatcherAssert.assertThat("Exception should not have been thrown", false);
+		}
+	}
+
+	/////
+	// Register
+	/////
+	@Test
+	public void testRegister() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		CloudFormationClient cfClient = getMockCloudFormationClient(200, 400, 200, false,
+				"CREATE_COMPLETE");
+		ReflectionTestUtils.setField(ecrApi, "cfClient", cfClient);
+
+		ecrApi.register(passwordEncoder);
+		BDDMockito.verify(passwordEncoder).encode(BDDMockito.any());
+		MatcherAssert
+				.assertThat(ecrIntegrationEntity.getWatchtowerSecret(), Matchers.notNullValue());
+		ArgumentCaptor<CreateStackRequest> createStackRequest = ArgumentCaptor
+				.forClass(CreateStackRequest.class);
+		BDDMockito.verify(cfClient).createStack(createStackRequest.capture());
+		MatcherAssert.assertThat(createStackRequest.getValue().stackName(),
+				Matchers.is("ecr-watchtower-webhook"));
+		BDDMockito.verify(cfClient).describeStacks(BDDMockito.any(DescribeStacksRequest.class));
+	}
+
+	@Test
+	public void testRegisterException() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		CloudFormationClient cfClient = getMockCloudFormationClient(200, 400, 400, true,
+				"CREATE_FAILED");
+		ReflectionTestUtils.setField(ecrApi, "cfClient", cfClient);
+
+		try {
+			ecrApi.register(passwordEncoder);
+			MatcherAssert.assertThat("Exception should have been thrown", false);
+		} catch (CloudFormationException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					Matchers.is("Create stack failed. See AWS for more details"));
+		}
+
+		BDDMockito.verify(passwordEncoder).encode(BDDMockito.any());
+		MatcherAssert
+				.assertThat(ecrIntegrationEntity.getWatchtowerSecret(), Matchers.notNullValue());
+		ArgumentCaptor<CreateStackRequest> createStackRequest = ArgumentCaptor
+				.forClass(CreateStackRequest.class);
+		BDDMockito.verify(cfClient).createStack(createStackRequest.capture());
+		MatcherAssert.assertThat(createStackRequest.getValue().stackName(),
+				Matchers.is("ecr-watchtower-webhook"));
+		BDDMockito.verify(cfClient).describeStacks(BDDMockito.any(DescribeStacksRequest.class));
+	}
+
+	/////
+	// Unregister
+	/////
+	@Test
+	public void testUnregister() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		CloudFormationClient cfClient = getMockCloudFormationClient(200, 200, 200, false,
+				"DELETE_COMPLETE");
+		ReflectionTestUtils.setField(ecrApi, "cfClient", cfClient);
+
+		ecrApi.unregister();
+		MatcherAssert.assertThat(ecrIntegrationEntity.getWatchtowerSecret(), Matchers.nullValue());
+		ArgumentCaptor<DeleteStackRequest> deleteStackRequest = ArgumentCaptor
+				.forClass(DeleteStackRequest.class);
+		BDDMockito.verify(cfClient).deleteStack(deleteStackRequest.capture());
+		MatcherAssert.assertThat(deleteStackRequest.getValue().stackName(),
+				Matchers.is("ecr-watchtower-webhook"));
+		BDDMockito.verify(cfClient).describeStacks(BDDMockito.any(DescribeStacksRequest.class));
+	}
+
+	@Test
+	public void testUnregisterExceptionNoStack() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		CloudFormationClient cfClient = getMockCloudFormationClient(200, 400, 400, true,
+				"Stack with id ecr-watchtower-webhook does not exist");
+		ReflectionTestUtils.setField(ecrApi, "cfClient", cfClient);
+
+		ecrApi.unregister();
+
+		MatcherAssert.assertThat(ecrIntegrationEntity.getWatchtowerSecret(), Matchers.nullValue());
+		ArgumentCaptor<DeleteStackRequest> deleteStackRequest = ArgumentCaptor
+				.forClass(DeleteStackRequest.class);
+		BDDMockito.verify(cfClient).deleteStack(deleteStackRequest.capture());
+		MatcherAssert.assertThat(deleteStackRequest.getValue().stackName(),
+				Matchers.is("ecr-watchtower-webhook"));
+		BDDMockito.verify(cfClient).describeStacks(BDDMockito.any(DescribeStacksRequest.class));
+	}
+
+	@Test
+	public void testUnregisterException() {
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		CloudFormationClient cfClient = getMockCloudFormationClient(200, 400, 400, true,
+				"DELETE_FAILED");
+		ReflectionTestUtils.setField(ecrApi, "cfClient", cfClient);
+
+		try {
+			ecrApi.unregister();
+			MatcherAssert.assertThat("Exception should have been thrown", false);
+		} catch (CloudFormationException e) {
+			MatcherAssert.assertThat(e.getMessage(),
+					Matchers.startsWith("DELETE_FAILED"));
+		}
+
+		MatcherAssert.assertThat(ecrIntegrationEntity.getWatchtowerSecret(), Matchers.nullValue());
+		ArgumentCaptor<DeleteStackRequest> deleteStackRequest = ArgumentCaptor
+				.forClass(DeleteStackRequest.class);
+		BDDMockito.verify(cfClient).deleteStack(deleteStackRequest.capture());
+		MatcherAssert.assertThat(deleteStackRequest.getValue().stackName(),
+				Matchers.is("ecr-watchtower-webhook"));
+		BDDMockito.verify(cfClient).describeStacks(BDDMockito.any(DescribeStacksRequest.class));
+	}
+
+	/////
+	// Unregister
+	/////
+
+	@Test
+	public void testRejectImage() {
+		ImageScan imageScan = new EcrImageScan(ecrIntegrationEntity.getApiLabel());
+		imageScan.setRegistry("1234567890");
+		imageScan.setRepository("myImage");
+		imageScan.setTag("latest");
+
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		EcrClient ecrClient = getMockEcrClient(400, true, 200, false);
+		ReflectionTestUtils.setField(ecrApi, "ecrClient", ecrClient);
+
+		ecrApi.rejectImage(imageScan, Collections.emptyList());
+
+		ArgumentCaptor<BatchDeleteImageRequest> deleteImageRequest = ArgumentCaptor
+				.forClass(BatchDeleteImageRequest.class);
+		BDDMockito.verify(ecrClient).batchDeleteImage(deleteImageRequest.capture());
+		MatcherAssert
+				.assertThat(deleteImageRequest.getValue().registryId(), Matchers.is("1234567890"));
+		MatcherAssert
+				.assertThat(deleteImageRequest.getValue().repositoryName(), Matchers.is("myImage"));
+		MatcherAssert.assertThat(deleteImageRequest.getValue().imageIds().get(0).toString(),
+				Matchers.is("ImageIdentifier(ImageTag=latest)"));
+
+		MatcherAssert.assertThat(logWatcher.getMessages().size(), Matchers.is(1));
+		MatcherAssert.assertThat(logWatcher.getFormattedMessages().get(0),
+				Matchers.is("Deleted image with tag 'latest' from repository 'myImage'"));
+	}
+
+	@Test
+	public void testRejectImageFailures() {
+		ImageScan imageScan = new EcrImageScan(ecrIntegrationEntity.getApiLabel());
+		imageScan.setRegistry("1234567890");
+		imageScan.setRepository("myImage");
+		imageScan.setTag("latest");
+
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		EcrClient ecrClient = getMockEcrClient(400, true, 400, true);
+		ReflectionTestUtils.setField(ecrApi, "ecrClient", ecrClient);
+
+		ecrApi.rejectImage(imageScan, Collections.emptyList());
+
+		ArgumentCaptor<BatchDeleteImageRequest> deleteImageRequest = ArgumentCaptor
+				.forClass(BatchDeleteImageRequest.class);
+		BDDMockito.verify(ecrClient).batchDeleteImage(deleteImageRequest.capture());
+		MatcherAssert
+				.assertThat(deleteImageRequest.getValue().registryId(), Matchers.is("1234567890"));
+		MatcherAssert
+				.assertThat(deleteImageRequest.getValue().repositoryName(), Matchers.is("myImage"));
+		MatcherAssert.assertThat(deleteImageRequest.getValue().imageIds().get(0).toString(),
+				Matchers.is("ImageIdentifier(ImageTag=latest)"));
+
+		MatcherAssert.assertThat(logWatcher.getMessages().size(), Matchers.is(1));
+		MatcherAssert.assertThat(logWatcher.getFormattedMessages().get(0),
+				Matchers.is(
+						"Failed to delete image with tag 'latest' from repository 'myImage': Cannot delete image"));
+	}
+
+	/////
+	// Get Security Report
+	/////
+
+	@Test
+	public void testGetSecurityReportForImage() {
+		ImageScan imageScan = new EcrImageScan(ecrIntegrationEntity.getApiLabel());
+		imageScan.setRegistry("1234567890");
+		imageScan.setRepository("myImage");
+		imageScan.setTag("latest");
+
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		EcrClient ecrClient = getMockEcrClient(200, false, 400, false);
+		ReflectionTestUtils.setField(ecrApi, "ecrClient", ecrClient);
+
+		ImageSecurityReport report = ecrApi.getSecurityReportForImage(imageScan);
+
+		ArgumentCaptor<DescribeImageScanFindingsRequest> describeFindingsRequest = ArgumentCaptor
+				.forClass(DescribeImageScanFindingsRequest.class);
+		BDDMockito.verify(ecrClient)
+				.describeImageScanFindingsPaginator(describeFindingsRequest.capture());
+		MatcherAssert
+				.assertThat(describeFindingsRequest.getValue().registryId(),
+						Matchers.is("1234567890"));
+		MatcherAssert
+				.assertThat(describeFindingsRequest.getValue().repositoryName(),
+						Matchers.is("myImage"));
+		MatcherAssert.assertThat(describeFindingsRequest.getValue().imageId().toString(),
+				Matchers.is("ImageIdentifier(ImageTag=latest)"));
+
+		MatcherAssert.assertThat(report.getFindings().size(), Matchers.is(1));
+		MatcherAssert.assertThat(report.getFindings().get(0).getFindingName(),
+				Matchers.is("findingName"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getDescription(),
+				Matchers.is("findingDescription"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getSeverity(), Matchers.is(
+				RulePriority.LOW));
+		MatcherAssert.assertThat(report.getFindings().get(0).getPackageName(), Matchers.is("a"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getPackageVersion(), Matchers.is("a"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getScore(), Matchers.is("a"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getVector(), Matchers.is("a"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getUri(),
+				Matchers.is("https://example.com"));
+	}
+
+	@Test
+	public void testGetSecurityReportForImageDefaultAttributes() {
+		ImageScan imageScan = new EcrImageScan(ecrIntegrationEntity.getApiLabel());
+		imageScan.setRegistry("1234567890");
+		imageScan.setRepository("myImage");
+		imageScan.setTag("latest");
+
+		EcrApi ecrApi = ecrIntegrationEntity.createApi();
+		EcrClient ecrClient = getMockEcrClient(200, true, 400, false);
+		ReflectionTestUtils.setField(ecrApi, "ecrClient", ecrClient);
+
+		ImageSecurityReport report = ecrApi.getSecurityReportForImage(imageScan);
+
+		ArgumentCaptor<DescribeImageScanFindingsRequest> describeFindingsRequest = ArgumentCaptor
+				.forClass(DescribeImageScanFindingsRequest.class);
+		BDDMockito.verify(ecrClient)
+				.describeImageScanFindingsPaginator(describeFindingsRequest.capture());
+		MatcherAssert
+				.assertThat(describeFindingsRequest.getValue().registryId(),
+						Matchers.is("1234567890"));
+		MatcherAssert
+				.assertThat(describeFindingsRequest.getValue().repositoryName(),
+						Matchers.is("myImage"));
+		MatcherAssert.assertThat(describeFindingsRequest.getValue().imageId().toString(),
+				Matchers.is("ImageIdentifier(ImageTag=latest)"));
+
+		MatcherAssert.assertThat(report.getFindings().size(), Matchers.is(1));
+		MatcherAssert.assertThat(report.getFindings().get(0).getFindingName(),
+				Matchers.is("findingName"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getDescription(),
+				Matchers.is("findingDescription"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getSeverity(), Matchers.is(
+				RulePriority.HIGH));
+		MatcherAssert.assertThat(report.getFindings().get(0).getPackageName(), Matchers.is("N/A"));
+		MatcherAssert
+				.assertThat(report.getFindings().get(0).getPackageVersion(), Matchers.is("N/A"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getScore(), Matchers.is("N/A"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getVector(), Matchers.is("N/A"));
+		MatcherAssert.assertThat(report.getFindings().get(0).getUri(),
+				Matchers.is("https://example.com"));
+	}
+
+	/////
+	// Mocks
+	/////
+
+	private static CloudFormationClient getMockCloudFormationClient(int createStackStatus,
+			int deleteStackStatus, int describeStacksStatus, boolean describeStacksException,
+			String describeStacksMessage) {
+		CloudFormationClient cfClient = BDDMockito.mock(CloudFormationClient.class);
+		BDDMockito.when(cfClient.serviceName()).thenReturn("cloudformation");
+		BDDMockito.when(cfClient.createStack(BDDMockito.any(CreateStackRequest.class)))
+				.thenReturn((CreateStackResponse) CreateStackResponse.builder().sdkHttpResponse(
+						SdkHttpResponse.builder().statusCode(createStackStatus).build()).build());
+		BDDMockito.when(cfClient.deleteStack(BDDMockito.any(DeleteStackRequest.class)))
+				.thenReturn((DeleteStackResponse) DeleteStackResponse.builder().sdkHttpResponse(
+						SdkHttpResponse.builder().statusCode(deleteStackStatus).build()).build());
+		if (describeStacksException) {
+			BDDMockito.doThrow(CloudFormationException.builder()
+					.awsErrorDetails(AwsErrorDetails.builder()
+							.errorCode("ValidationError")
+							.errorMessage(describeStacksMessage)
+							.serviceName("cloudformation").build())
+					.statusCode(describeStacksStatus)
+					.requestId("12345").build())
+					.when(cfClient).describeStacks(BDDMockito.any(DescribeStacksRequest.class));
+		} else {
+			BDDMockito.when(cfClient.describeStacks(BDDMockito.any(DescribeStacksRequest.class)))
+					.thenReturn((DescribeStacksResponse) DescribeStacksResponse.builder()
+							.stacks(Stack.builder().stackStatus(describeStacksMessage).build())
+							.sdkHttpResponse(
+									SdkHttpResponse.builder().statusCode(describeStacksStatus)
+											.build())
+							.build());
+		}
+		BDDMockito.when(cfClient.waiter())
+				.thenReturn(CloudFormationWaiter.builder().client(cfClient).build());
+		return cfClient;
+	}
+
+	private static EcrClient getMockEcrClient(int describeFindingsStatus, boolean defaultAttributes,
+			int deleteImageStatus, boolean deleteImageFailure) {
+		EcrClient ecrClient = BDDMockito.mock(EcrClient.class);
+		BDDMockito.when(ecrClient.serviceName()).thenReturn("ecr");
+		BDDMockito.when(ecrClient.batchDeleteImage(BDDMockito.any(BatchDeleteImageRequest.class)))
+				.thenReturn((BatchDeleteImageResponse) BatchDeleteImageResponse.builder()
+						.failures(deleteImageFailure ? Collections.singletonList(
+								ImageFailure.builder().failureReason("Cannot delete image").build())
+								: Collections.emptyList())
+						.sdkHttpResponse(SdkHttpResponse.builder()
+								.statusCode(deleteImageStatus).build())
+						.build());
+		BDDMockito.when(ecrClient
+				.describeImageScanFindings(BDDMockito.any(DescribeImageScanFindingsRequest.class)))
+				.thenReturn((DescribeImageScanFindingsResponse) DescribeImageScanFindingsResponse
+						.builder().imageScanFindings(ImageScanFindings.builder().findings(
+								getMockImageFinding(defaultAttributes)).build())
+						.sdkHttpResponse(
+								SdkHttpResponse.builder().statusCode(describeFindingsStatus)
+										.build()).build());
+
+		BDDMockito.when(ecrClient.describeImageScanFindingsPaginator(
+				BDDMockito.any(DescribeImageScanFindingsRequest.class)))
+				.thenAnswer(i -> new DescribeImageScanFindingsIterable(ecrClient,
+						(DescribeImageScanFindingsRequest) i.getArguments()[0]));
+		return ecrClient;
+	}
+
+	private static ImageScanFinding getMockImageFinding(boolean defaultAttributes) {
+		return ImageScanFinding.builder()
+				.attributes(defaultAttributes ? Collections.emptyList() : Arrays.asList(
+						Attribute.builder().key("package_name").value("a").build(),
+						Attribute.builder().key("package_version").value("a").build(),
+						Attribute.builder().key("CVSS2_SCORE").value("a").build(),
+						Attribute.builder().key("CVSS2_VECTOR").value("a").build()))
+				.severity(defaultAttributes ? FindingSeverity.HIGH : FindingSeverity.LOW)
+				.name("findingName")
+				.description("findingDescription")
+				.uri("https://example.com")
+				.build();
+	}
+}


### PR DESCRIPTION
- Add documentation for image scans
- Add ECR integration tests
- Clean up error handling
- Fix paging on image scan results
- Remove reference to SCM
- Fix testConnection and unregister errors for cases that should succeed
- Set default value for register state on existing rows
